### PR TITLE
rTorrent: Improve rTorrent docs

### DIFF
--- a/docs/applications/rtorrent.mdx
+++ b/docs/applications/rtorrent.mdx
@@ -17,23 +17,13 @@ sudo box install rtorrent
 ```
 This command will compile and configure rTorrent for use on your slot.
 
-Before installation, you'll receive a prompt asking you which version of rTorrent you'd like to install. These version tags correspond with recent releases supported for your OS the the `feature-bind` branch. The `feature-bind` branch is considered the unstable head of development on GitHub. This branch is not guaranteed to compile properly and may fail. If it does, please consider reinstalling rTorrent with one of the released versions.
+Before installation, a prompt will display asking which version of rTorrent you'd like to install. `Repo` is unstable and should only be used a last resort. `0.9.8, 0.9.7, 0.9.6` include performance and stability patches. `UDNS` includes release improvements and has additional stability changes for UDP trackers.
 
-After installation, there will be two 3 new packages installed: xmlrpc-c, libtorrent-rakshasa, and rtorrent. Due to potential packaging conflicts with your distribution's repository, the package `rtorrent` has been held by apt and will not be marked for upgrade. You may see apt issue a warning regarding the held `rtorrent` package. This is completely normal and it means the apt mark is working as expected.
+After installation, there will be many new packages installed: c-ares, curl, mktorrent, udns, xmlrpc-c, libtorrent-rakshasa, and rtorrent. Please disregard warnings received about the held `rtorrent` apt package. The custom version of `curl` is required for `c-ares` support. `rtorrent` works better with the DNS improvements.
 
-#### Patching
-If you would like to patch the rTorrent or libtorrent-rakshasa source, the rTorrent compile will check if `/root/libtorrent-rakshasa-{libtorrentver}.patch` and `/root/rtorrent-{rtorrentver}.patch` exist. If they do, then the installer will automatically patch the rTorrent and/or libtorrent-rakshasa source with these patches before they are compiled.
-
-Note that libtorrent-rakshasa (used by rTorrent) is a different library than libtorrent-rasterbar (used by Deluge and qBittorrent). For details on how to patch libtorrent-rasterbar, refer to the [Deluge](/applications/deluge#libtorrent-patching) and [qBittorrent](/applications/qbittorrent#libtorrent-patching) pages.
-
-Examples of valid patch filenames are:
-
-```
-/root/libtorrent-rakshasa-0.13.8.patch
-/root/rtorrent-0.9.8.patch
-```
-
-You must supply your own patches!
+:::info
+Instructions for software developers to apply patches are in the [`developer` documentation](rtorrent#patching)
+:::
 
 ## How to upgrade/downgrade
 
@@ -43,7 +33,7 @@ rTorrent has a upgrade helper script in `box`. To access the function, use the c
 sudo box upgrade rtorrent
 ```
 
-The menu asking which version you'd like to install will pop up. Pick one. Afterwards, the script will rebuild rTorrent against your latest libraries.
+A prompt will display asking which version you'd like to install. Select one to rebuild rTorrent against your latest libraries.
 
 ## How to Access
 
@@ -54,31 +44,29 @@ In order to access the ruTorrent GUI, you'll first need to install it with `box`
 
 ### Command Line
 
-rTorrent runs as a daemon thanks to the screen application. Thus, in order to connect to the curses UI, you simply need to attach to the running screen. For all users, the rtorrent screen is simply named rtorrent. In order to connect to the rtorrent screen session, simply issue the command:
+rTorrent runs as a daemon on a Linux Screen. To connect to the curses GUI, you need to attach to the running screen named `rtorrent`. Simply issue the following command:
 ```bash
 screen -r rtorrent
 ```
-When done with the session, do not quit rTorrent. Rather, you should detach from the screen, so that rTorrent remains running in the background.
+When done with the session, do not quit rTorrent. Rather, you should detach from the screen, so that rTorrent remains running in the background. To do this, press the keys: `ctrl-a, ctrl-d`
 
-To do this, press the keys: `ctrl-a, ctrl-d`
-
-You will be returned to the command line and you screen will remain running in the background.
-
-For help on using the curses UI, check the rTorrent user guide: here.
+You will be returned to the command line and you screen will remain running in the background. For help on using the curses UI, check the rTorrent user guide.
 
 ## Service Management
 The systemd script for rTorrent can be found at
 ```bash
 /etc/systemd/system/rtorrent@.service
 ```
-As a multi-user script, you must call it with the username to change the service status for.
-import SystemdTabs from '../snippets/systemdtabs.mdx';
+As a multi-user script, you must call it with the username to change the service status.
 
-<SystemdTabs service="rtorrent@<username>"/>
+To restart rtorrent, type the following command and replace `<username>` with your swizzin user:
+```bash
+systemctl restart rtorrent@<username>
+```
 
 ## Configuration
 
-The configuration of rTorrent is a file that lives in your home folder called .rtorrent.rc.There are not many reasons you should need to edit this file (and please note that many of the options should not be reconfigured (such as: ip, bind, network.scgi.open_local), otherwise, you may find that your client has stopped working.
+The rTorrent configuration file is located in `/home/user/.rtorrent.rc`. You should be careful when editing this file. The `rtorrent` client may stop working properly. Things like `ip`, `bind`, `network.scgi.open_local` etc. should not be changed.
 
 ### Default Download Location
 
@@ -89,7 +77,9 @@ Files downloaded by rTorrent will be placed in `~/torrents/rtorrent` by default.
 Similarly, any files in the default download directory (`~/torrents/rtorrent`) will be available for browsing via the web server at the location: `https://<yourhostname.ltd>/rtorrent.downloads`
 
 ## Extensions
+:::info
 You can install additional themes and plugins using the [`rtx` helper script](/scripts/rtx)
+:::
 
 ## Connect to other clients
 
@@ -97,14 +87,14 @@ Generally speaking, most of the other clients connect to rTorrent, not the other
 
 ### Unix Sockets
 Rather than exposing a local, insecure TCP port the rTorrent client creates a socket that can only be listened to by your own user.
+```bash
+/run/<username>/.rtorrent.sock
+```
 
-This socket lives at:
-
-`/run/<username>/.rtorrent.sock`
-
-If you were inputting this to a program, you need to pre-pend the unix:// protocol designation, thus your final socket may look something like:
-
-`unix:///run/liara/.rtorrent.sock`
+If you are adding this to a program, you need to pre-pend the unix:// protocol designation:
+```bash
+unix:///run/liara/.rtorrent.sock
+```
 
 ### RPC Mounts
 
@@ -230,3 +220,20 @@ Please fix your [`quota` installation](quota.mdx).
 
 ### The cloudlfare plugin does not work
 It's fine. That issue is basically cosmetic only, and you can just disable the plugin. That is done in the plugin tab in the bottom-half of the screen. Right-click on the cloudflare plugin, and disable it.
+
+
+## Developer
+
+### Patching
+If you would like to patch the rTorrent or libtorrent-rakshasa source, the rTorrent compile will check if `/root/libtorrent-rakshasa-{libtorrentver}.patch` and `/root/rtorrent-{rtorrentver}.patch` exist. If they do, then the installer will automatically patch the rTorrent and/or libtorrent-rakshasa source with these patches before they are compiled.
+
+Note that libtorrent-rakshasa (used by rTorrent) is a different library than libtorrent-rasterbar (used by Deluge and qBittorrent). For details on how to patch libtorrent-rasterbar, refer to the [Deluge](/applications/deluge#libtorrent-patching) and [qBittorrent](/applications/qbittorrent#libtorrent-patching) pages.
+
+Examples of valid patch filenames are:
+
+```
+/root/libtorrent-rakshasa-0.13.8.patch
+/root/rtorrent-0.9.8.patch
+```
+
+You must supply your own patches!


### PR DESCRIPTION
This commit improves readability and communication on the `rtorrent` docs. It also updates some old information.